### PR TITLE
Integrate Strip with Angular

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@angular/platform-server": "^19.2.0",
         "@angular/router": "^19.2.0",
         "@angular/ssr": "^19.2.0",
+        "@stripe/stripe-js": "^7.2.0",
         "express": "^4.18.2",
         "firebase": "^11.6.1",
         "rxjs": "~7.8.0",
@@ -5394,6 +5395,15 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "dev": true
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.2.0.tgz",
+      "integrity": "sha512-BXlt6BsFE599yOATuz78FiW9z4SyipCH3j1SDyKWe/3OUBdhcOr/BWnBi1xrtcC2kfqrTJjgvfH2PTfMPRmbTw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.4",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@angular/platform-server": "^19.2.0",
     "@angular/router": "^19.2.0",
     "@angular/ssr": "^19.2.0",
+    "@stripe/stripe-js": "^7.2.0",
     "express": "^4.18.2",
     "firebase": "^11.6.1",
     "rxjs": "~7.8.0",

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { SignInComponent } from './features/auth/sign-in/sign-in.component';
 import { HomeComponent } from './features/home/home.component';
 import { SignUpComponent } from './features/auth/sign-up/sign-up.component';
 import { ClientProjectApprovedComponent } from './features/clientproject/client-project-approved/client-project-approved.component';
+import { PaymentComponent } from './features/payment/payment.component';
 
 export const routes: Routes = [
   { path: '', redirectTo: '/home', pathMatch: 'full' },
@@ -10,6 +11,7 @@ export const routes: Routes = [
   { path: 'sign-in', component: SignInComponent },
   { path: 'sign-up', component: SignUpComponent },
   { path: 'clientProjects/approved', component: ClientProjectApprovedComponent },
+  { path: 'payment', component: PaymentComponent },
   { path: '**', redirectTo: '/home' },
 
 ];

--- a/src/app/core/services/payment/payment.service.spec.ts
+++ b/src/app/core/services/payment/payment.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PaymentService } from './payment.service';
+
+describe('PaymentService', () => {
+  let service: PaymentService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PaymentService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/services/payment/payment.service.ts
+++ b/src/app/core/services/payment/payment.service.ts
@@ -1,0 +1,23 @@
+// src/app/services/payment.service.ts
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+interface SessionResponse { sessionId: string; }
+
+@Injectable({ providedIn: 'root' })
+export class PaymentService {
+  apiUrl='http://localhost:5021/api/payment';
+
+  constructor(private http: HttpClient) {}
+
+  async createCheckoutSession(amountCents: number): Promise<string> {
+    const res = await firstValueFrom(
+      this.http.post<SessionResponse>(
+        `${this.apiUrl}/create-checkout-session`,
+        { amount: amountCents }
+      )
+    );
+    return res.sessionId;
+  }
+}

--- a/src/app/core/services/payment/stripe.service.spec.ts
+++ b/src/app/core/services/payment/stripe.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { StripeService } from './stripe.service';
+
+describe('StripeService', () => {
+  let service: StripeService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(StripeService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/services/payment/stripe.service.ts
+++ b/src/app/core/services/payment/stripe.service.ts
@@ -1,0 +1,13 @@
+// src/app/services/stripe.service.ts
+import { Injectable } from '@angular/core';
+import { loadStripe, Stripe } from '@stripe/stripe-js';
+import { environment } from '../../../../environments/environment'; 
+
+@Injectable({ providedIn: 'root' })
+export class StripeService {
+  private stripePromise = loadStripe(environment.stripe.publishableKey);
+
+  async getStripe(): Promise<Stripe> {
+    return (await this.stripePromise)!;
+  }
+}

--- a/src/app/features/payment/payment.component.html
+++ b/src/app/features/payment/payment.component.html
@@ -1,0 +1,10 @@
+<div class="flex overflow-hidden rounded-xl shadow">
+  <input type="number" [(ngModel)]="amount" placeholder="Enter the amount" [disabled]="loading"
+    class="flex-1 px-4 py-2 text-black focus:outline-none placeholder-gray-500" />
+  <button (click)="pay()" [disabled]="loading"
+    class="bg-[#DEBD63] px-4 py-2 font-bold text-black hover:bg-yellow-500 transition">
+    {{ loading ? 'Transferring...' : '+' }}
+  </button>
+
+  <div *ngIf="message" class="text-red-600 alert">{{ message }}</div>
+</div>

--- a/src/app/features/payment/payment.component.spec.ts
+++ b/src/app/features/payment/payment.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PaymentComponent } from './payment.component';
+
+describe('PaymentComponent', () => {
+  let component: PaymentComponent;
+  let fixture: ComponentFixture<PaymentComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PaymentComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PaymentComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/payment/payment.component.ts
+++ b/src/app/features/payment/payment.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit } from '@angular/core';
+import { StripeService } from '../../core/services/payment/stripe.service';
+import { PaymentService } from '../../core/services/payment/payment.service';
+import { FormsModule } from '@angular/forms';
+import {CommonModule} from '@angular/common'
+import { loadStripe, Stripe } from '@stripe/stripe-js';
+
+@Component({
+  selector: 'app-payment',
+  templateUrl: './payment.component.html',
+  imports: [FormsModule,CommonModule],
+})
+export class PaymentComponent implements OnInit {
+  amount = 0;
+  message = '';
+  loading = false;
+  stripe!: Stripe;  
+
+  constructor(
+    private stripeSrv: StripeService,
+    private paymentSrv: PaymentService
+  ) {}
+
+  async ngOnInit() {
+    this.stripe = await this.stripeSrv.getStripe();
+  }
+
+  async pay() {
+    if (this.amount <= 0) {
+      this.message = 'Please enter a valid amount.';
+      return;
+    }
+    this.loading = true;
+    try {
+      const sessionId = await this.paymentSrv.createCheckoutSession(this.amount * 100);
+      const { error } = await this.stripe.redirectToCheckout({ sessionId });
+      if (error) this.message = `Payment failed: ${error.message}`;
+    } catch (err: any) {
+      this.message = `Error: ${err.message}`;
+    } finally {
+      this.loading = false;
+    }
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+  <script src="https://js.stripe.com/v3/"></script>
 </head>
 <body class="flex flex-col min-h-screen">
   <app-root></app-root>


### PR DESCRIPTION
****Description****  
This PR adds Stripe payment integration to the Angular frontend using Stripe Checkout.

****Key Changes****  
- Added StripeService  
  - Loads Stripe using `@stripe/stripe-js`  
  - Uses `environment.stripe.publishableKey` for initialization  
  - Exposes `getStripe()` to return the Stripe instance  

- Added PaymentService  
  - Defines `createCheckoutSession(amountCents: number)`  
  - Sends POST request to `/api/payment/create-checkout-session`  
  - Expects and returns Stripe session ID  

- PaymentComponent 
  - Accepts amount as input  
  - Uses StripeService to load Stripe  
  - Calls PaymentService to create checkout session  
  - Redirects user to Stripe-hosted checkout page  

****Environment Setup****  
- Reads publishable key from `environment.stripe.publishableKey`  


****Dependencies****  
- `@stripe/stripe-js` for client-side integration  