### PR TITLE
Add "Edit Profile" Button for Own Profile Only

### DIFF
--- a/src/app/features/profile/profile.component.html
+++ b/src/app/features/profile/profile.component.html
@@ -28,14 +28,23 @@
         class="text-sm text-gray-400 hover:underline"
         >{{ userProfile.phone }}</a
       ><br />
-      <button
-      *ngIf="!isOwnProfile()"
+          <button
+      *ngIf="!isOwnProfile(); else editButton"
       class="mt-2 bg-black text-white px-4 py-1 rounded"
       [routerLink]="['/messages']"
       [queryParams]="{ userId: userId }"
     >
       Contact
     </button>
+
+    <ng-template #editButton>
+      <button
+        class="mt-2 bg-black text-white px-4 py-1 rounded"
+        [routerLink]="['/profile', userId, 'edit']"
+      >
+        Edit Profile
+      </button>
+    </ng-template>
     </div>
   </div>
 

--- a/src/app/features/profile/profile.component.ts
+++ b/src/app/features/profile/profile.component.ts
@@ -4,6 +4,7 @@ import { RouterModule } from '@angular/router';
 import { UserService } from '../../core/services/user/user.service';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
+import { Subscription } from 'rxjs';
 @Component({
   selector: 'app-profile',
   imports: [RouterLink,RouterModule,CommonModule],
@@ -14,21 +15,28 @@ export class ProfileComponent {
   userId = ''; // Replace it later
   userProfile: any;
   currentUserId:any;
+   private routeSub!: Subscription;
   constructor(
     private userService: UserService,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    
   ) {}
 
   ngOnInit(): void {
-    const userId = this.route.snapshot.paramMap.get('id'); // get user id from url
+    //const userId = this.route.snapshot.paramMap.get('id'); // get user id from url
     this.currentUserId =  this.userService.getCurrentUserId();
-    if (userId) {
-      this.userId = userId;
-      this.userService.getUserProfile(userId).subscribe({
-        next: (data) => this.userProfile = data,
-        error: (err) => console.error('Error fetching profile:', err)
-      });
-    }
+    this.routeSub = this.route.paramMap.subscribe(params => {
+      const userId = params.get('id');
+      if (userId) {
+        this.userId = userId;
+
+        //get user profile
+        this.userService.getUserProfile(userId).subscribe({
+          next: data => this.userProfile = data,
+          error: err => console.error('Error fetching profile:', err)
+        });
+      }
+    });
   }
   isOwnProfile(): boolean {
     this.currentUserId =  this.userService.getCurrentUserId();


### PR DESCRIPTION
### Description:

- Added an "Edit Profile" button to the profile page that only appears if the logged-in user is viewing their own profile. Otherwise, a "Contact" button is shown.
- Used *ngIf ... else to toggle between the two buttons based on whether userId matches currentUserId.
- Updated the edit route 
- The logic for checking the current user remains unchanged. Tested and confirmed the button updates correctly when navigating between profiles.